### PR TITLE
Simplify plop script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 node_modules/
-dev/
-.env
 .DS_Store
 
 apps/**/configuration.ts
 apps/**/node_modules/
 apps/**/package-lock.json
+
+# Just in case we accidentally generate these during maintenance.
+demoDocs/
+demoDotcom/
+demoFeynman/

--- a/apps/searchSummary/README.md
+++ b/apps/searchSummary/README.md
@@ -5,7 +5,7 @@ This app provides working sample code for implementing a Search Summary UI that'
 The Search Summary UI is characterized by:
 
 - A search box for entering a natural-language query. This can take the form of a question or just search terms.
-- A \*\*list of search results.
+- A list of search results.
 - A summary of search results that are most relevant to the query, with citations.
 
 A user will typically scan the summary for points of interest, which is faster than reviewing the list of search results. If an aspect of the summary catches their eye, they'll dig deeper into the cited search result. They'll repeat this pattern until they've reviewed all of the interesting information that was relevant to their query.

--- a/plopComponents/application/actions.js
+++ b/plopComponents/application/actions.js
@@ -4,10 +4,7 @@ const { exec } = require("child_process");
 const appTypeToTemplateDir = {
   search: "search",
   searchSummary: "searchSummary",
-  questionAndAnswer: "questionAndAnswer",
-  demoDocs: "searchSummary",
-  demoFeynman: "searchSummary",
-  demoDotcom: "searchSummary"
+  questionAndAnswer: "questionAndAnswer"
 };
 
 let appName;

--- a/plopComponents/application/actions.js
+++ b/plopComponents/application/actions.js
@@ -5,7 +5,9 @@ const appTypeToTemplateDir = {
   search: "search",
   searchSummary: "searchSummary",
   questionAndAnswer: "questionAndAnswer",
-  preset: "searchSummary"
+  demoDocs: "searchSummary",
+  demoFeynman: "searchSummary",
+  demoDotcom: "searchSummary"
 };
 
 let appName;
@@ -36,8 +38,6 @@ module.exports = {
   },
 
   getActions: (data, dir) => {
-    // const configFile = ["preset", "searchSummary"].includes(data.appType) ? "/src/configuration.ts" : ".env";
-    // const configTemplate = ["preset", "searchSummary"].includes(data.appType) ? "configuration.hbs" : "env.hbs";
     return [
       { type: "Create app folder" },
       { type: "Copy files" },

--- a/plopComponents/application/prompts.js
+++ b/plopComponents/application/prompts.js
@@ -1,39 +1,3 @@
-const DEFAULT_CONFIGS = {
-  demoDocs: {
-    customerId: "1366999410",
-    corpusId: "1",
-    apiKey: "zqt_UXrBcnI2UXINZkrv4g1tQPhzj02vfdtqYJIDiA",
-    appName: "Vectara Docs",
-    questions: [
-      "How do I enable hybrid search?",
-      "How is data encrypted?",
-      "What is a textless corpus?",
-      "How do I configure OAuth?"
-    ]
-  },
-
-  demoDotcom: {
-    customerId: "1366999410",
-    corpusId: "2",
-    apiKey: "zqt_UXrBcnnt4156FZqMtzK8OEoZqcR0OrecS5Bb6Q",
-    appName: "Vectara.com Q&A",
-    questions: ["What is grounded generation?", "How do I index a document?", "What does Vectara do?", "Who is Amr?"]
-  },
-
-  demoFeynman: {
-    customerId: "1366999410",
-    corpusId: "3",
-    apiKey: "zqt_UXrBclYURJiAW9MiKT1L60EJC6iaIoWYj_bSJg",
-    appName: "Ask Feynman",
-    questions: [
-      "Who figured out the motion of the planets?",
-      "Is light a particle or a wave?",
-      "What is a Pauli Spin matrix?",
-      "What's the importance of the two slit experiment?"
-    ]
-  }
-};
-
 module.exports = {
   renderPrompts: async (inquirer) => {
     const appTypeAns = await inquirer.prompt({
@@ -57,65 +21,49 @@ Which type of codebase would you like to create?\n`,
         {
           name: "Question and Answer | Expects the user to ask a question instead of entering search terms.",
           value: "questionAndAnswer"
-        },
-        {
-          name: "Demo: Docs          | A preconfigured demo for asking questions about Vectara's docs.",
-          value: "demoDocs"
-        },
-        {
-          name: "Demo: Science       | Another preconfigured demo, but with Richard Feynman's lectures.",
-          value: "demoFeynman"
-        },
-        {
-          name: "Demo: Vectara.com   | Another preconfigured demo, but with content from our website.",
-          value: "demoDotcom"
         }
       ]
     });
 
-    const isDemoUi = ["demoDocs", "demoFeynman", "demoDotcom"].includes(appTypeAns.appType);
-
     const customAppDirNameAns = await inquirer.prompt({
-      when: () => !isDemoUi,
       type: "input",
       name: "customAppDirName",
       message: "What directory name would you like to use?"
     });
 
     const appNameAns = await inquirer.prompt({
-      when: () => !isDemoUi,
       type: "input",
       name: "appName",
-      message: "What would you like to name your application?"
+      message: "What do you want to name your application?",
+      default: "Vectara Docs Example"
     });
 
     const customerIdAns = await inquirer.prompt({
-      when: () => !isDemoUi,
       type: "input",
       name: "customerId",
-      message: "What's your Vectara Customer ID?"
+      message: "What's your Vectara Customer ID?",
+      default: "1366999410"
     });
 
     const corpusIdAns = await inquirer.prompt({
-      when: () => !isDemoUi,
       type: "input",
       name: "corpusId",
-      message: "What Vectara Corpus ID is associated with your data?"
+      message: "What's the Corpus ID of the corpus that contains your data?",
+      default: "1"
     });
 
     const apiKeyAns = await inquirer.prompt({
-      when: () => !isDemoUi,
       type: "input",
       name: "apiKey",
-      message: "What is your Vectara QueryService API Key (This can be safely shared)?"
+      message: "What's your QueryService API Key? This must have access to the corpus.",
+      default: "zqt_UXrBcnI2UXINZkrv4g1tQPhzj02vfdtqYJIDiA"
     });
 
     const questions = [];
     const haveQuestionsAns = await inquirer.prompt({
-      when: () => !isDemoUi,
       type: "confirm",
       name: "value",
-      message: "Would you like to add sample questions for your users?"
+      message: "Do you want to suggest questions for your users to try? If not, we'll provide default questions."
     });
 
     if (haveQuestionsAns.value) {
@@ -127,7 +75,7 @@ Which type of codebase would you like to create?\n`,
         let questionAns = await inquirer.prompt({
           type: "input",
           name: "value",
-          message: `Enter sample question ${numQuestions}:`
+          message: `Enter suggested question ${numQuestions}:`
         });
 
         questions.push(questionAns.value);
@@ -135,12 +83,10 @@ Which type of codebase would you like to create?\n`,
         moreQuestionsAns = await inquirer.prompt({
           type: "confirm",
           name: "value",
-          message: "Would you like to add more questions?"
+          message: "Want to suggest another question?"
         });
       } while (moreQuestionsAns.value);
     }
-
-    const appDirName = isDemoUi ? appTypeAns.appType : customAppDirNameAns.customAppDirName;
 
     const promptAnswers = {
       ...appTypeAns,
@@ -148,18 +94,21 @@ Which type of codebase would you like to create?\n`,
       ...corpusIdAns,
       ...apiKeyAns,
       ...appNameAns,
-      appDirName,
+      appDirName: customAppDirNameAns.customAppDirName,
       questions
     };
 
-    // Overlay default answers if app is a preset app.
-    const ans = {
-      ...promptAnswers,
-      ...(DEFAULT_CONFIGS[appDirName] ?? {})
-    };
+    promptAnswers.questions = JSON.stringify(
+      promptAnswers.questions.length > 0
+        ? promptAnswers.questions
+        : [
+            "How do I enable hybrid search?",
+            "How is data encrypted?",
+            "What is a textless corpus?",
+            "How do I configure OAuth?"
+          ]
+    );
 
-    ans.questions = JSON.stringify(ans.questions);
-
-    return ans;
+    return promptAnswers;
   }
 };

--- a/plopComponents/application/prompts.js
+++ b/plopComponents/application/prompts.js
@@ -25,39 +25,56 @@ Which type of codebase would you like to create?\n`,
       ]
     });
 
+    const dataSourceAns = await inquirer.prompt({
+      type: "list",
+      name: "dataSource",
+      message:
+        "Want to connect to your own data or use our sample data? Sample data consists of pages scraped from docs.vectara.com.",
+      choices: [
+        { name: "Use my own data", value: "customData" },
+        {
+          name: "Use the Vectara Docs sample data",
+          value: "sampleData"
+        }
+      ]
+    });
+
+    const isCustomData = dataSourceAns.dataSource === "customData";
+
     const appNameAns = await inquirer.prompt({
+      when: () => isCustomData,
       type: "input",
       name: "appName",
-      message: "What do you want to name your application? Just accept all defaults to generate a working example.",
-      default: "Vectara Docs Example"
+      message: "What do you want to name your application?"
     });
 
     const customerIdAns = await inquirer.prompt({
+      when: () => isCustomData,
       type: "input",
       name: "customerId",
-      message: "What's your Vectara Customer ID?",
-      default: "1366999410"
+      message: "What's your Vectara Customer ID?"
     });
 
     const corpusIdAns = await inquirer.prompt({
+      when: () => isCustomData,
       type: "input",
       name: "corpusId",
-      message: "What's the Corpus ID of the corpus that contains your data?",
-      default: "1"
+      message: "What's the Corpus ID of the corpus that contains your data?"
     });
 
     const apiKeyAns = await inquirer.prompt({
+      when: () => isCustomData,
       type: "input",
       name: "apiKey",
-      message: "What's your QueryService API Key? This must have access to the corpus.",
-      default: "zqt_UXrBcnI2UXINZkrv4g1tQPhzj02vfdtqYJIDiA"
+      message: "What's your QueryService API Key? This must have access to the corpus."
     });
 
     const questions = [];
     const haveQuestionsAns = await inquirer.prompt({
+      when: () => isCustomData,
       type: "confirm",
       name: "value",
-      message: "Do you want to suggest questions for your users to try?",
+      message: "Do you want the UI to suggest questions for people to try?",
       default: false
     });
 
@@ -83,28 +100,29 @@ Which type of codebase would you like to create?\n`,
       } while (moreQuestionsAns.value);
     }
 
-    const promptAnswers = {
-      ...appTypeAns,
-      ...customerIdAns,
-      ...corpusIdAns,
-      ...apiKeyAns,
-      ...appNameAns,
-      // Convert app name to kebab case.
-      appDirName: appNameAns.appName.toLowerCase().replace(/[\s_]+/g, "-"),
-      questions
-    };
-
-    promptAnswers.questions = JSON.stringify(
-      promptAnswers.questions.length > 0
-        ? promptAnswers.questions
-        : [
+    return isCustomData
+      ? {
+          appType: appTypeAns.appType,
+          appName: appNameAns.appName,
+          appDirName: appNameAns.appName.toLowerCase().replace(/[\s_]+/g, "-"),
+          customerId: customerIdAns.customerId,
+          corpusId: corpusIdAns.corpusId,
+          apiKey: apiKeyAns.apiKey,
+          questions: JSON.stringify(questions)
+        }
+      : {
+          appType: appTypeAns.appType,
+          appName: "Vectara Docs Example",
+          appDirName: "vectara-docs-example",
+          customerId: "1366999410",
+          corpusId: "1",
+          apiKey: "zqt_UXrBcnI2UXINZkrv4g1tQPhzj02vfdtqYJIDiA",
+          questions: JSON.stringify([
             "How do I enable hybrid search?",
             "How is data encrypted?",
             "What is a textless corpus?",
             "How do I configure OAuth?"
-          ]
-    );
-
-    return promptAnswers;
+          ])
+        };
   }
 };

--- a/plopComponents/application/prompts.js
+++ b/plopComponents/application/prompts.js
@@ -25,16 +25,10 @@ Which type of codebase would you like to create?\n`,
       ]
     });
 
-    const customAppDirNameAns = await inquirer.prompt({
-      type: "input",
-      name: "customAppDirName",
-      message: "What directory name would you like to use?"
-    });
-
     const appNameAns = await inquirer.prompt({
       type: "input",
       name: "appName",
-      message: "What do you want to name your application?",
+      message: "What do you want to name your application? Just accept all defaults to generate a working example.",
       default: "Vectara Docs Example"
     });
 
@@ -63,7 +57,7 @@ Which type of codebase would you like to create?\n`,
     const haveQuestionsAns = await inquirer.prompt({
       type: "confirm",
       name: "value",
-      message: "Do you want to suggest questions for your users to try? If not, we'll provide default questions.",
+      message: "Do you want to suggest questions for your users to try?",
       default: false
     });
 
@@ -95,7 +89,8 @@ Which type of codebase would you like to create?\n`,
       ...corpusIdAns,
       ...apiKeyAns,
       ...appNameAns,
-      appDirName: customAppDirNameAns.customAppDirName,
+      // Convert app name to kebab case.
+      appDirName: appNameAns.appName.toLowerCase().replace(/[\s_]+/g, "-"),
       questions
     };
 

--- a/plopComponents/application/prompts.js
+++ b/plopComponents/application/prompts.js
@@ -63,7 +63,8 @@ Which type of codebase would you like to create?\n`,
     const haveQuestionsAns = await inquirer.prompt({
       type: "confirm",
       name: "value",
-      message: "Do you want to suggest questions for your users to try? If not, we'll provide default questions."
+      message: "Do you want to suggest questions for your users to try? If not, we'll provide default questions.",
+      default: false
     });
 
     if (haveQuestionsAns.value) {

--- a/plopComponents/application/prompts.js
+++ b/plopComponents/application/prompts.js
@@ -13,13 +13,13 @@ module.exports = {
 Create a sample UI codebase powered by the Vectara Platform.
 Which type of codebase would you like to create?\n`,
       choices: [
-        { name: "Search              | A typical semantic search UI. Connect it to your own corpus.", value: "search" },
+        { name: "Search              | A typical semantic search UI.", value: "search" },
         {
-          name: "Search Summary      | Like search, but preceded by a summary of the most relevant results.",
+          name: "Search Summary      | A semantic search UI preceded by a summary of the most relevant results.",
           value: "searchSummary"
         },
         {
-          name: "Question and Answer | Expects the user to ask a question instead of entering search terms.",
+          name: "Question and Answer | Expects the user to ask a question and provides them a concise answer.",
           value: "questionAndAnswer"
         }
       ]

--- a/plopComponents/application/prompts.js
+++ b/plopComponents/application/prompts.js
@@ -1,30 +1,36 @@
-const vectaraWebsiteQuestions = require(`${__dirname}/../../sampleData/vectara-website/queries.json`);
-const vectaraDocsQuestions = require(`${__dirname}/../../sampleData/vectara-docs/queries.json`);
-const askFeynmanQuestions = require(`${__dirname}/../../sampleData/ask-feynman/queries.json`);
-
 const DEFAULT_CONFIGS = {
-  "vectara-docs": {
+  demoDocs: {
     customerId: "1366999410",
     corpusId: "1",
     apiKey: "zqt_UXrBcnI2UXINZkrv4g1tQPhzj02vfdtqYJIDiA",
     appName: "Vectara Docs",
-    questions: JSON.stringify(vectaraDocsQuestions.questions)
+    questions: [
+      "How do I enable hybrid search?",
+      "How is data encrypted?",
+      "What is a textless corpus?",
+      "How do I configure OAuth?"
+    ]
   },
 
-  "vectara-website": {
+  demoDotcom: {
     customerId: "1366999410",
     corpusId: "2",
     apiKey: "zqt_UXrBcnnt4156FZqMtzK8OEoZqcR0OrecS5Bb6Q",
     appName: "Vectara.com Q&A",
-    questions: JSON.stringify(vectaraWebsiteQuestions.questions)
+    questions: ["What is grounded generation?", "How do I index a document?", "What does Vectara do?", "Who is Amr?"]
   },
 
-  "ask-feynman": {
+  demoFeynman: {
     customerId: "1366999410",
     corpusId: "3",
     apiKey: "zqt_UXrBclYURJiAW9MiKT1L60EJC6iaIoWYj_bSJg",
     appName: "Ask Feynman",
-    questions: JSON.stringify(askFeynmanQuestions.questions)
+    questions: [
+      "Who figured out the motion of the planets?",
+      "Is light a particle or a wave?",
+      "What is a Pauli Spin matrix?",
+      "What's the importance of the two slit experiment?"
+    ]
   }
 };
 
@@ -33,37 +39,41 @@ module.exports = {
     const appTypeAns = await inquirer.prompt({
       type: "list",
       name: "appType",
-      message: "What type of UI would you like to create?",
-      choices: [
-        { name: "Search", value: "search" },
-        { name: "Search Summary", value: "searchSummary" },
-        { name: "Question and Answer", value: "questionAndAnswer" },
-        { name: "Preconfigured demo", value: "preset" }
-      ]
-    });
+      message: `
+╭―――――――――――――――――――――――――――╮
+│                           │
+│     Vectara Sample UI     │
+│                           │
+╰―――――――――――――――――――――――――――╯
 
-    const isDemoUi = appTypeAns.appType === "preset";
-
-    const presetAppDirNameAns = await inquirer.prompt({
-      when: () => isDemoUi,
-      type: "list",
-      name: "presetAppDirName",
-      message: "Choose a pre-built sample UI.",
+Create a sample UI codebase powered by the Vectara Platform.
+Which type of codebase would you like to create?\n`,
       choices: [
+        { name: "Search              | A typical semantic search UI. Connect it to your own corpus.", value: "search" },
         {
-          name: "Vectara Docs - Answer questions about Vectara's platform documentation",
-          value: "vectara-docs"
+          name: "Search Summary      | Like search, but preceded by a summary of the most relevant results.",
+          value: "searchSummary"
         },
         {
-          name: "Vectara.com Q&A - Answer questions about Vectara's company website",
-          value: "vectara-website"
+          name: "Question and Answer | Expects the user to ask a question instead of entering search terms.",
+          value: "questionAndAnswer"
         },
         {
-          name: "Ask Feynman - Answer questions about Richard Feynman's lectures",
-          value: "ask-feynman"
+          name: "Demo: Docs          | A preconfigured demo for asking questions about Vectara's docs.",
+          value: "demoDocs"
+        },
+        {
+          name: "Demo: Science       | Another preconfigured demo, but with Richard Feynman's lectures.",
+          value: "demoFeynman"
+        },
+        {
+          name: "Demo: Vectara.com   | Another preconfigured demo, but with content from our website.",
+          value: "demoDotcom"
         }
       ]
     });
+
+    const isDemoUi = ["demoDocs", "demoFeynman", "demoDotcom"].includes(appTypeAns.appType);
 
     const customAppDirNameAns = await inquirer.prompt({
       when: () => !isDemoUi,
@@ -130,7 +140,7 @@ module.exports = {
       } while (moreQuestionsAns.value);
     }
 
-    const appDirName = presetAppDirNameAns.presetAppDirName ?? customAppDirNameAns.customAppDirName;
+    const appDirName = isDemoUi ? appTypeAns.appType : customAppDirNameAns.customAppDirName;
 
     const promptAnswers = {
       ...appTypeAns,
@@ -139,7 +149,7 @@ module.exports = {
       ...apiKeyAns,
       ...appNameAns,
       appDirName,
-      questions: JSON.stringify(questions)
+      questions
     };
 
     // Overlay default answers if app is a preset app.
@@ -147,6 +157,8 @@ module.exports = {
       ...promptAnswers,
       ...(DEFAULT_CONFIGS[appDirName] ?? {})
     };
+
+    ans.questions = JSON.stringify(ans.questions);
 
     return ans;
   }

--- a/plopfile.mjs
+++ b/plopfile.mjs
@@ -18,12 +18,6 @@ export default function (plop) {
   plop.setGenerator("vectara-create", {
     description: "Configuration Variables",
     prompts: async (inquirer) => {
-      await inquirer.prompt({
-        type: "input",
-        name: "acknowledgePrimer",
-        message: "Welcome to Vectara's UI Creator!\nPress Enter to continue."
-      });
-
       const answers = await renderApplicationPrompts(inquirer);
 
       return {

--- a/sampleData/ask-feynman/queries.json
+++ b/sampleData/ask-feynman/queries.json
@@ -1,8 +1,0 @@
-{
-  "questions": [
-    "Who figured out the motion of the planets?",
-    "Is light a particle or a wave?",
-    "What is a Pauli Spin matrix?",
-    "What's the importance of the two slit experiment?"
-  ]
-}

--- a/sampleData/vectara-docs/queries.json
+++ b/sampleData/vectara-docs/queries.json
@@ -1,8 +1,0 @@
-{
-  "questions": [
-    "How do I enable hybrid search?",
-    "How is data encrypted?",
-    "What is a textless corpus?",
-    "How do I configure OAuth?"
-  ]
-}

--- a/sampleData/vectara-website/queries.json
+++ b/sampleData/vectara-website/queries.json
@@ -1,8 +1,0 @@
-{
-  "questions": [
-    "What is grounded generation?",
-    "How do I index a document?",
-    "What does Vectara do?",
-    "Who is Amr?"
-  ]
-}


### PR DESCRIPTION
Closes https://github.com/vectara/create-ui/issues/1
Blocked on https://github.com/vectara/create-ui/pull/18

## Changes

I redesigned the initial prompt to provide more info up-front and require fewer steps.

![image](https://github.com/vectara/create-ui/assets/1238659/22c41f5d-37b8-436f-b0a7-36a16a186e65)

I also removed the question for the directory name. Instead, now the script generates a directory name by kebab-casing the app name.

![image](https://github.com/vectara/create-ui/assets/1238659/97666a45-6efa-4cf2-8d2e-9dcf4433616e)

Continuing from the default app name shown above, all questions default to values for the Feynman example. If this is weird maybe we can just add a branching question earlier that prompts the user to either generate a working example or to connect to their own data source. @mrderyk WDYT?

![image](https://github.com/vectara/create-ui/assets/1238659/015a65b0-0db3-4eb8-9a09-91dee63be41f)

That would simplify things in the last step, which defaults to Feynman-oriented questions.

![image](https://github.com/vectara/create-ui/assets/1238659/47334601-57e0-4a81-b86b-40e7d07e175b)
