### PR TITLE
Require Node version 18 or higher.

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Use this tool to:
 
 ### 1. Install Node and NPM
 
-Create-UI expects you to have [Node and NPM](https://nodejs.org/en/download) installed on your system.
+Create-UI expects you to have [Node v18 or higher and NPM](https://nodejs.org/en/download) installed on your system.
 
 ### 2. Generate a codebase
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "@vectara/create-ui",
-  "version": "0.0.5",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectara/create-ui",
-      "version": "0.0.5",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@vectara/stream-query-client": "^3.0.0",
         "minimist": "^1.2.8",
         "plop": "^4.0.0"
       },
@@ -33,6 +32,9 @@
         "react-router-dom": "^6.8.2",
         "rimraf": "^5.0.5",
         "typescript": "^5.3.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@babel/runtime": {
@@ -649,11 +651,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@vectara/stream-query-client": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@vectara/stream-query-client/-/stream-query-client-3.0.0.tgz",
-      "integrity": "sha512-wrG4vzeyEBfrlquaL2+ON+fMhkVQIxzP54iJ8Flhca6899rNnmjgW5pMBYG89LOLjothnnEoDvCDHyVVk0xD2Q=="
     },
     "node_modules/accepts": {
       "version": "1.3.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@vectara/create-ui",
   "version": "2.0.0",
+  "engines": {
+    "node": ">=18"
+  },
   "description": "The fastest way to generate a Vectara-powered sample codebase for a range of user interfaces",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Now if the consumer doesn't have the supported Node version, they'll see this error:

```
npm ERR! code ENOTSUP
npm ERR! notsup Unsupported engine for @vectara/create-ui@2.0.0: wanted: {"node":"^18"} (current: {"node":"12.22.9","npm":"6.14.15"})
npm ERR! notsup Not compatible with your version of node/npm: @vectara/create-ui@2.0.0
npm ERR! notsup Not compatible with your version of node/npm: @vectara/create-ui@2.0.0
npm ERR! notsup Required: {"node":"^18"}
npm ERR! notsup Actual:   {"npm":"6.14.15","node":"12.22.9"}

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/cj/.npm/_logs/2024-07-19T19_40_28_169Z-debug.log
```