### PR TITLE
feat: accept custom domain for query endpoint

### DIFF
--- a/apps/chat/src/contexts/SearchContext.tsx
+++ b/apps/chat/src/contexts/SearchContext.tsx
@@ -203,6 +203,7 @@ export const SearchContextProvider = ({ children }: Props) => {
       const streamQueryConfig: ApiV2.StreamQueryConfig = {
         apiKey: search.apiKey!,
         customerId: search.customerId!,
+        domain: search.endpoint,
         query: value,
         corpusKey: search.corpusKey!,
         search: {

--- a/apps/questionAndAnswer/src/contexts/SearchContext.tsx
+++ b/apps/questionAndAnswer/src/contexts/SearchContext.tsx
@@ -256,6 +256,7 @@ export const SearchContextProvider = ({ children }: Props) => {
         const streamQueryConfig: ApiV2.StreamQueryConfig = {
           apiKey: search.apiKey!,
           customerId: search.customerId!,
+          domain: search.endpoint,
           query: value,
           corpusKey: search.corpusKey!,
           search: {

--- a/apps/search/src/contexts/SearchContext.tsx
+++ b/apps/search/src/contexts/SearchContext.tsx
@@ -145,6 +145,7 @@ export const SearchContextProvider = ({ children }: Props) => {
         const streamQueryConfig: ApiV2.StreamQueryConfig = {
           apiKey: search.apiKey!,
           customerId: search.customerId!,
+          domain: search.endpoint,
           query: value,
           corpusKey: search.corpusKey!,
           search: {

--- a/apps/searchSummary/src/contexts/SearchContext.tsx
+++ b/apps/searchSummary/src/contexts/SearchContext.tsx
@@ -248,6 +248,7 @@ export const SearchContextProvider = ({ children }: Props) => {
         const streamQueryConfig: ApiV2.StreamQueryConfig = {
           apiKey: search.apiKey!,
           customerId: search.customerId!,
+          domain: search.endpoint,
           query: value,
           corpusKey: search.corpusKey!,
           search: {

--- a/plopComponents/actions.js
+++ b/plopComponents/actions.js
@@ -42,7 +42,7 @@ module.exports = {
       {
         type: "add",
         path: `${process.cwd()}/{{appDirName}}/src/configuration.ts`,
-        templateFile: `${dir}/plopTemplates/configuration.hbs`,
+        templateFile: `${dir}/plopTemplates/${data.appType === "chat" ? "chatConfiguration.hbs" : "configuration.hbs"}`,
         force: true
       },
       () =>

--- a/plopComponents/prompts.js
+++ b/plopComponents/prompts.js
@@ -63,7 +63,7 @@ Which type of codebase would you like to create?\n`,
       });
     }
 
-    const isCustomData = dataSourceAns.dataSource === "customData";
+    const isCustomData = dataSourceAnswer.dataSource === "customData";
 
     const appNameAnswer = await inquirer.prompt({
       when: () => isCustomData,
@@ -94,6 +94,15 @@ Which type of codebase would you like to create?\n`,
         "What's your API Key? This must have access to the corpus. We suggest limiting its privileges to the QueryService."
     });
 
+    const domainAnswer = await inquirer.prompt({
+      when: () => isCustomData,
+      type: "input",
+      name: "domain",
+      message:
+        "Are you self-hosting or proxying the Vectara API at a custom domain? If so, enter it now. Or connect directly to Vectara's hosted API by accepting the default. If you're not sure, accept the default.",
+      default: "https://api.vectara.io"
+    });
+
     const questions = [];
     const haveQuestionsAnswer = await inquirer.prompt({
       when: () => isCustomData,
@@ -118,7 +127,7 @@ Which type of codebase would you like to create?\n`,
 
         questions.push(questionAnswer.value);
 
-        moreQuestionsAns = await inquirer.prompt({
+        moreQuestionsAnswer = await inquirer.prompt({
           type: "confirm",
           name: "value",
           message: "Want to suggest another question?"
@@ -134,6 +143,7 @@ Which type of codebase would you like to create?\n`,
           customerId: customerIdAnswer.customerId,
           corpusKey: corpusKeyAnswer.corpusKey,
           apiKey: apiKeyAnswer.apiKey,
+          domain: domainAnswer.domain,
           fcs: fcsAnswer?.value ?? false,
           questions: JSON.stringify(questions)
         }
@@ -144,6 +154,7 @@ Which type of codebase would you like to create?\n`,
           customerId: "1366999410",
           corpusKey: "vectara-docs_1",
           apiKey: "zqt_UXrBcnI2UXINZkrv4g1tQPhzj02vfdtqYJIDiA",
+          domain: domainAnswer.domain,
           fcs: true,
           questions: JSON.stringify([
             "How do I enable hybrid search?",

--- a/plopTemplates/chatConfiguration.hbs
+++ b/plopTemplates/chatConfiguration.hbs
@@ -7,5 +7,4 @@ export const configuration: Config = {
   apiKey: "{{apiKey}}",
   endpoint: "{{domain}}",
   questions: {{{questions}}},
-  fcs: {{fcs}},
 };

--- a/plopTemplates/env.hbs
+++ b/plopTemplates/env.hbs
@@ -3,5 +3,5 @@ REACT_APP_customer_id={{customerId}}
 REACT_APP_app_title={{appName}}
 REACT_APP_search_title={{appName}}
 REACT_APP_api_key={{apiKey}}
-REACT_APP_endpoint=api.vectara.io
+REACT_APP_domain={{domain}}
 REACT_APP_questions={{{questions}}}

--- a/sampleConfigurations/chat-configuration.ts
+++ b/sampleConfigurations/chat-configuration.ts
@@ -6,6 +6,5 @@ export const configuration: Config = {
   appTitle: "Chat UI",
   apiKey: "zqt_UXrBcnI2UXINZkrv4g1tQPhzj02vfdtqYJIDiA",
   endpoint: "api.vectara.io",
-  questions: ["What's hybrid search?", "What's the Vectara platform?"],
-  fcs: true
+  questions: ["What's hybrid search?", "What's the Vectara platform?"]
 };


### PR DESCRIPTION
This PR allows for accepting a custom domain to send query requests to.
Previously, all apps created with create-ui would only send requests to API endpoints under https://api.vectara.io.